### PR TITLE
enables hot reloading of dylibs on macos

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,6 +360,17 @@ impl<'a> Build<'a> {
         // If the library already exists, load it.
         loop {
             if tmp_path.exists() {
+                // This is some voodoo to enable reloading of dylib on mac os
+                if cfg!(target_os = "macos") { 
+                    std::process::Command::new("install_name_tool")
+                        .current_dir(tmp_path.parent().unwrap())
+                        .arg("-id")
+                        .arg("''")
+                        .arg(tmp_path.file_name().unwrap())
+                        .output()
+                        .expect("ls command failed to start");
+                }
+
                 let lib = libloading::Library::new(&tmp_path)
                     .map(Some)
                     .map_err(|err| LoadError::Library { err })?;
@@ -368,7 +379,6 @@ impl<'a> Build<'a> {
                 let tmp = TempLibrary { build_timestamp, path, lib };
                 return Ok(tmp);
             }
-
             // Copy the dylib to the tmp location.
             let tmp_dir = tmp_path.parent().expect("temp dylib path has no parent");
             std::fs::create_dir_all(tmp_dir).map_err(|err| LoadError::Io { err })?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,6 +356,7 @@ impl<'a> Build<'a> {
     pub fn load(self) -> Result<TempLibrary, LoadError> {
         let dylib_path = self.dylib_path();
         let tmp_path = self.tmp_dylib_path();
+        let tmp_dir = tmp_path.parent().expect("temp dylib path has no parent");
 
         // If the library already exists, load it.
         loop {
@@ -363,10 +364,10 @@ impl<'a> Build<'a> {
                 // This is some voodoo to enable reloading of dylib on mac os
                 if cfg!(target_os = "macos") { 
                     std::process::Command::new("install_name_tool")
-                        .current_dir(tmp_path.parent().unwrap())
+                        .current_dir(tmp_dir)
                         .arg("-id")
                         .arg("''")
-                        .arg(tmp_path.file_name().unwrap())
+                        .arg(tmp_path.file_name().expect("temp dylib path has no file name"))
                         .output()
                         .expect("ls command failed to start");
                 }
@@ -380,7 +381,6 @@ impl<'a> Build<'a> {
                 return Ok(tmp);
             }
             // Copy the dylib to the tmp location.
-            let tmp_dir = tmp_path.parent().expect("temp dylib path has no parent");
             std::fs::create_dir_all(tmp_dir).map_err(|err| LoadError::Io { err })?;
             std::fs::copy(&dylib_path, &tmp_path).map_err(|err| LoadError::Io { err })?;
         }


### PR DESCRIPTION
Now uses std::process::Command to execute `install_name_tool -id '' libfoo.dylib`